### PR TITLE
Allow for Glimpse.RavenDB to not crash on background threads

### DIFF
--- a/Glimpse.RavenDb/Profiler.cs
+++ b/Glimpse.RavenDb/Profiler.cs
@@ -16,7 +16,18 @@ namespace Glimpse.RavenDb
         public void Setup(IInspectorContext context)
         {
             Profiler.MessageBroker = context.MessageBroker;
-            Profiler.ExecutionTimerFactory = context.TimerStrategy;
+            Profiler.ExecutionTimerFactory =  () =>
+            {
+                try
+                {
+                    return context.TimerStrategy();
+                }
+                catch
+                {
+                    // Avoid exception being thrown from threads without access to request store
+                    return null;
+                }
+            };
         }
     }
 


### PR DESCRIPTION
I think this would fix #7.

I've looked at how Glimpse seems to work around the issue of same code running in background threads, and the solution seems to be to swallow the exception.

I understand you haven't been working with RavenDB, but since I've done this for our usage, thought to at least let you know.

Thanks
